### PR TITLE
readme: Update 21 ref, add links - Flask, nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The intention is to have many people/organizations run a hashfs service,
 creating a decentralized storage mesh.
 
 This project aims towards a robust, high performance API service
-using flask, nginx and 21BC.
+using [Flask](http://flask.pocoo.org), [nginx](https://www.nginx.com) and
+[21](https://21.co/).
 
 
 Theory of Operation


### PR DESCRIPTION
This small change updates the reference of "21BC" to just "21" now that
the client can be used as well. Also added links to Flask, nginx and 21
(if OK).
